### PR TITLE
#59 - specifies no decompression required for NEE data

### DIFF
--- a/R/fct_read.R
+++ b/R/fct_read.R
@@ -4,7 +4,7 @@ read_nee <- function(
     as_decimal = TRUE
 ) {
 
-  nee <- container_support |> AzureStor::storage_load_rds(filename)
+  nee <- container_support |> AzureStor::storage_load_rds(filename, type = "none")
 
   if (as_decimal) {
     nee <- nee |>


### PR DESCRIPTION
closes #59 

Specifies `type = "none"` to the NEE `storage_load_rds()` function call, thus avoiding a console message about unknown compression.