### PR TITLE
107 heatmap nee

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @primary-owner and @secondary-owner will be requested for
+# review when someone opens a pull request.
+*       @matt-dray @craig-parylo 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,6 +15,7 @@ Imports:
     AzureStor,
     bsicons,
     bslib (>= 0.7.0),
+    colourpicker,
     config (>= 0.3.1),
     data.table,
     dplyr,

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2024
-COPYRIGHT HOLDER: Golem User
+COPYRIGHT HOLDER: The Strategy Unit

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2024 Golem User
+Copyright (c) 2024 The Strategy Unit
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -615,8 +615,8 @@ app_ui <- function(request) {
                 width = 350,
                 open = TRUE,
 
-                bslib::input_switch(
-                  id = "toggle_contextual_baseline_range",
+                shiny::checkboxInput(
+                  inputId = "toggle_contextual_baseline_range",
                   label = bslib::tooltip(
                     trigger = list(
                       "Show 80% range?",
@@ -626,8 +626,8 @@ app_ui <- function(request) {
                   ),
                   value = TRUE
                 ),
-                bslib::input_switch(
-                  id = "toggle_contextual_baseline_quadrants",
+                shiny::checkboxInput(
+                  inputId = "toggle_contextual_baseline_quadrants",
                   label = bslib::tooltip(
                     trigger = list(
                       "Show quadrant lines?",
@@ -637,8 +637,8 @@ app_ui <- function(request) {
                   ),
                   value = TRUE
                 ),
-                bslib::input_switch(
-                  id = "toggle_contextual_baseline_schemecode",
+                shiny::checkboxInput(
+                  inputId = "toggle_contextual_baseline_schemecode",
                   label = bslib::tooltip(
                     trigger = list(
                       "Show scheme codes?",
@@ -693,8 +693,8 @@ app_ui <- function(request) {
                 width = 350,
                 open = TRUE,
 
-                bslib::input_switch(
-                  id = "toggle_contextual_trendline_otherschemes",
+                shiny::checkboxInput(
+                  inputId = "toggle_contextual_trendline_otherschemes",
                   label = bslib::tooltip(
                     trigger = list(
                       "Show other schemes?",
@@ -704,8 +704,8 @@ app_ui <- function(request) {
                   ),
                   value = FALSE
                 ),
-                bslib::input_switch(
-                  id = "toggle_contextual_trendline_horizon_timeline",
+                shiny::checkboxInput(
+                  inputId = "toggle_contextual_trendline_horizon_timeline",
                   label = bslib::tooltip(
                     trigger = list(
                       "Show horizon on timeline?",
@@ -715,8 +715,8 @@ app_ui <- function(request) {
                   ),
                   value = TRUE
                 ),
-                bslib::input_switch(
-                  id = "toggle_contextual_trendline_horizon_overlay",
+                shiny::checkboxInput(
+                  inputId = "toggle_contextual_trendline_horizon_overlay",
                   label = bslib::tooltip(
                     trigger = list(
                       "Show horizon as overlay?",
@@ -726,8 +726,8 @@ app_ui <- function(request) {
                   ),
                   value = FALSE
                 ),
-                bslib::input_switch(
-                  id = "toggle_contextual_trendline_average",
+                shiny::checkboxInput(
+                  inputId = "toggle_contextual_trendline_average",
                   label = bslib::tooltip(
                     trigger = list(
                       "Show pre-baseline average?",

--- a/README.md
+++ b/README.md
@@ -2,35 +2,50 @@
 
 <!-- badges: start -->
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
-
 <!-- badges: end -->
 
 ## Purpose
 
-An app to compare schemes' mitigator selections as part of the National Hospital Programme (NHP) modelling process. It's [deployed to Posit Connect](https://connect.strategyunitwm.nhs.uk/nhp/mitigator-comparisons/).
+An app built with [{shiny}](https://shiny.posit.co/), [{golem}](https://thinkr-open.github.io/golem/) and [{bslib}](https://rstudio.github.io/bslib/) to explore and compare schemes' mitigator selections as part of the National Hospital Programme (NHP) modelling process. 
 
-This tool is designed for use by model-relationship managers (MRMs) in discussion with schemes so that the mitigator selections can be refined before being finalised. Also, some of the scheme-level code here may support a standalone national-level report that's being developed separately.
+This tool is designed primarily for use by model-relationship managers (MRMs) in discussion with schemes so that the mitigator selections can be refined before being finalised.
 
-This app replaces an original static report ([deployment](https://connect.strategyunitwm.nhs.uk/nhp/mitigators-comparison-report), [source](https://github.com/The-Strategy-Unit/nhp_peers_params)) that started to become tricky to manage and interpret without interactivity.
+The app is [deployed to Posit Connect](https://connect.strategyunitwm.nhs.uk/nhp/mitigator-comparisons/) (login/permissions required).
 
-## Requirements
+## Run the app
 
-Some environmental variables are needed to fetch data, for example. You will need to add a `.Renviron` file to the project directory that contains the variables named in the `.Renviron.example` file. You can ask a member of the Data Science team for the values to populate this file. Remember to restart your session after you've updated your `.Renviron` file.
+### Deploy
 
-## Techincal
+You can redeploy the app to Posit Connect using the `dev/03_deploy.R` script.
+This usually happens after a new GitHub release/Git tag.
 
-### Major packages
+The script checks for the 'app ID' in the `rsconnect/` folder of your local project root, which is generated when you first deploy.
+Otherwise you can find the ID by opening the app from the Posit Connect 'Content' page and then looking for 'Content ID' in the Settings > Info panel of the interface.
 
-The app is built with [{shiny}](https://shiny.posit.co/), the [{golem}](https://thinkr-open.github.io/golem/) Shiny-as-a-package framework and [{bslib}](https://rstudio.github.io/bslib/) for theming.
+### Locally
 
-### Mitigator data
+You can run the app locally, but some environmental variables are needed to fetch data, for example.
+You will need to add a `.Renviron` file to the project directory that contains the variables named in the `.Renviron.example` file.
+You can ask a member of the Data Science team for the values to populate this file.
+Remember to restart your session after you've updated your `.Renviron` file.
 
-The mitigators for each scheme's model scenarios are stored on Azure as large json files. One small element of these files is the 'params' item, which includes the mitigator selections.
+## Data
 
-To avoid the app having to read the entire json file for each scheme's model scenario, there is a system to pre-prepare the params alone. [A scheduled Quarto document on Posit Connect](https://connect.strategyunitwm.nhs.uk/nhp/tagged-runs-params-report/) has code to select the appropriate json file, extract the params and [save them as an RDS file to a pin](https://connect.strategyunitwm.nhs.uk/content/32c7f642-e420-448d-b888-bf655fc8fa8b/) on Posit Connect; it also saves [a CSV file to another pin](https://connect.strategyunitwm.nhs.uk/content/811dbaf9-18fe-43aa-bf8e-06b0df66004e/) that contains metadata about the model scenarios. The app then reads data from these pins using [the {pins} package](https://pins.rstudio.com/). A [blogpost by the Data Science team](https://the-strategy-unit.github.io/data_science/blogs/posts/2024-05-22-storing-data-safely/#posit-connect-pins) contains note on authenticating RStudio with Posit Connect, should you need to.
+### Mitigators
 
-Schemes run many scenarios, but the app only displays data from a single json. The correct file is read because the MRMs tell the Data Science team which particular scenario should be labelled on Azure with a 'run stage' of 'initial', 'intermediate' or 'final'. There's [a handy lookup table](https://connect.strategyunitwm.nhs.uk/nhp/tagged_runs/nhp-tagged-runs.html) where you can see which files have been labelled for each scheme.
+The mitigators for each scheme's model scenarios are stored on Azure as large json files.
+One small element of these files is the 'params' item, which includes the mitigator selections.
 
-### Supporting data
+To avoid the app having to read the entire json file for each scheme's model scenario, there is a system to pre-prepare the params alone.
+[A scheduled Quarto document on Posit Connect](https://connect.strategyunitwm.nhs.uk/nhp/tagged-runs-params-report/) has code to select the appropriate json file, extract the params and [save them as an RDS file to a pin](https://connect.strategyunitwm.nhs.uk/content/32c7f642-e420-448d-b888-bf655fc8fa8b/) on Posit Connect; it also saves [a CSV file to another pin](https://connect.strategyunitwm.nhs.uk/content/811dbaf9-18fe-43aa-bf8e-06b0df66004e/) that contains metadata about the model scenarios.
+The app then reads data from these pins using [the {pins} package](https://pins.rstudio.com/).
+A [blogpost by the Data Science team](https://the-strategy-unit.github.io/data_science/blogs/posts/2024-05-22-storing-data-safely/#posit-connect-pins) contains note on authenticating RStudio with Posit Connect, should you need to.
 
-Supporting data is fetched from Azure. This includes lookups for mitigators and schemes, as well as data from the National Elicitation Exercise (NEE).
+Schemes run many scenarios, but the app only displays data from a single json.
+The correct file is read because the MRMs tell the Data Science team which particular scenario should be labelled on Azure with a 'run stage' of 'final' (the default) 'intermediate' or 'initial'.
+There's [a handy lookup table](https://connect.strategyunitwm.nhs.uk/nhp/tagged_runs/nhp-tagged-runs.html) (login/permissions required) where you can see which files have been labelled for each scheme.
+
+### Supporting
+
+Supporting data is fetched from Azure.
+This includes lookups for mitigators and schemes, as well as data from the National Elicitation Exercise (NEE).

--- a/dev/03_deploy.R
+++ b/dev/03_deploy.R
@@ -53,7 +53,7 @@ rsconnect::deployApp(
     "DESCRIPTION",
     "app.R"
   ),
-  appId = rsconnect::deployments(".")$appID,  # 298
+  appId = rsconnect::deployments(".")$appID,
   lint = FALSE,
   forceUpdate = TRUE
 )


### PR DESCRIPTION
closes #106 
closes #107 

# Heatmap NEE and aggregate summaries
This PR adds the ability to vew National Eliciation Exercise (NEE) values for mitigators and aggregate summaries (minimum, maximum and mean) values for schemes and mitigators on the heatmap plot.

## Screenshots
![image](https://github.com/user-attachments/assets/b83a4d75-0efd-4ecb-a7da-96f40eb5a899)

![image](https://github.com/user-attachments/assets/8dd84d50-aa73-4aae-b24e-1b8b7a8b39b7)

## Additional features

- Focal scheme is now identified using a pin emoji 📌. Hopefully this doesn't encounter the [unicode display issue](https://github.com/The-Strategy-Unit/nhp_inputs_report_app/pull/113#pullrequestreview-2550466441) mentioned in PR 113.
- Fixed a bug introduced in #113 affecting the alphabetical display of schemes, where the focal scheme was incorrectly ordered.

## Known issues
There is a message on this PR indicating it can't be automatically merged which will need addressing. I suspect this is related to 'drift' occuring between this PR and #113, and I hope is easily resolved.