### PR TITLE
127 toggle point estimates

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -71,7 +71,8 @@ app_server <- function(input, output, session) {
   dat_reactive <- shiny::reactive({
     dat_return <- update_dat_values(
       dat = dat,
-      values_displayed = input$values_displayed
+      values_displayed = input$values_displayed,
+      include_point_estimates = input$include_point_estimates
     )
 
     return(dat_return)

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -164,6 +164,19 @@ app_ui <- function(request) {
               status = "primary",
               right = TRUE
             ),
+            shinyWidgets::materialSwitch(
+              inputId = "include_point_estimates",
+              label = bslib::tooltip(
+                trigger = list(
+                  "Include point estimates?",
+                  bsicons::bs_icon("info-circle")
+                ),
+                "Should point-estimates indicating zero mitigation be included in the results? Toggle off (default) to exclude all point-estimates indicating 0% mitigation, Toggle on to show all mitigator values."
+              ),
+              value = FALSE,
+              status = "primary",
+              right = TRUE
+            )
           )
         )
       ),

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -171,7 +171,7 @@ app_ui <- function(request) {
                   "Include point estimates?",
                   bsicons::bs_icon("info-circle")
                 ),
-                "Should point-estimates indicating zero mitigation be included in the results? Toggle off (default) to exclude all point-estimates indicating 0% mitigation, Toggle on to show all mitigator values."
+                "Should point-estimates indicating zero mitigation be included in the results? Toggle off (default) to exclude all point-estimates indicating 0% mitigation, toggle on to show all mitigator values."
               ),
               value = FALSE,
               status = "primary",

--- a/man/update_dat_values.Rd
+++ b/man/update_dat_values.Rd
@@ -4,12 +4,14 @@
 \alias{update_dat_values}
 \title{Update dat to reflect the user's preferred values}
 \usage{
-update_dat_values(dat, values_displayed)
+update_dat_values(dat, values_displayed, include_point_estimates = FALSE)
 }
 \arguments{
 \item{dat}{Tibble of data - as produced from `populate_table` in `fct_tabulate.R`}
 
 \item{values_displayed}{Character - the value in `input$values_displayed` indicating the user's preferred view}
+
+\item{include_point_estimates}{Boolean - the value in `input$include_point_estimates` indicating whether point-estimates of 0% mitigation (100% prediction) are to be included}
 }
 \value{
 Tibble of data with the 'value_' and 'nee_' fields updated to match the user's preferred values


### PR DESCRIPTION
closes #127 

# Toggle point estimates of 0% mitigation
This PR introduces a method of including or excluding point-estimates of 0% mitigation from the visualisations.

![image](https://github.com/user-attachments/assets/4879fe00-9740-4850-af9e-4097ff310532)

## Point-ranges
![image](https://github.com/user-attachments/assets/3f28ff94-e052-4af7-b29b-9f35f1e4dea5)

## Heat maps
![image](https://github.com/user-attachments/assets/0918505b-79b1-429d-b1d1-688241a05c67)

## Baseline comparison
![image](https://github.com/user-attachments/assets/85c9c5f1-d992-41e0-8a40-6acea471f84b)

## Trendline comparison
![image](https://github.com/user-attachments/assets/20217f8e-3539-4e85-9bb1-48270bf1a7e1)

