### PR TITLE
Clarify the 'about' accordions

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -208,6 +208,18 @@ app_ui <- function(request) {
                 #title = "Point-range settings",
                 open = TRUE,
                 width = 350,
+
+                bslib::accordion(
+                  open = FALSE,
+                  bslib::accordion_panel(
+                    title = "Information",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("card-text"),
+                      "Describe this visualisation."
+                    ),
+                    md_file_to_html("app", "text", "about_pointrange.md")
+                  )
+                ),
                 shiny::checkboxInput(
                   inputId = "toggle_mitigator_code_pointrange",
                   label = bslib::tooltip(
@@ -285,14 +297,6 @@ app_ui <- function(request) {
                   label = "Bookmark ",
                   icon = shiny::icon("bookmark", lib = "glyphicon"),
                   style = "color: #fff; background-color: #337ab7; border-color: #2e6da4"
-                ),
-
-                bslib::accordion(
-                  open = FALSE,
-                  bslib::accordion_panel(
-                    title = "About",
-                    md_file_to_html("app", "text", "about_pointrange.md")
-                  )
                 )
               ), # end sidebar
               shiny::plotOutput("pointrange")
@@ -314,6 +318,18 @@ app_ui <- function(request) {
                 #title = "Density settings",
                 open = TRUE,
                 width = 350,
+
+                bslib::accordion(
+                  open = FALSE,
+                  bslib::accordion_panel(
+                    title = "Information",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("card-text"),
+                      "Describe this visualisation."
+                    ),
+                    md_file_to_html("app", "text", "about_distributions.md")
+                  )
+                ),
 
                 shiny::checkboxInput(
                   inputId = "toggle_mixture_distribution_ecdf",
@@ -343,15 +359,8 @@ app_ui <- function(request) {
                   label = "Bookmark ",
                   icon = shiny::icon("bookmark", lib = "glyphicon"),
                   style = "color: #fff; background-color: #337ab7; border-color: #2e6da4"
-                ),
-
-                bslib::accordion(
-                  open = FALSE,
-                  bslib::accordion_panel(
-                    title = "About",
-                    md_file_to_html("app", "text", "about_distributions.md")
-                  )
                 )
+
               ), # end sidebar
               shiny::plotOutput('mixture_distributions')
             )
@@ -380,6 +389,19 @@ app_ui <- function(request) {
               sidebar = bslib::sidebar(
                 width = 350,
                 open = TRUE,
+
+                bslib::accordion(
+                  open = FALSE,
+                  bslib::accordion_panel(
+                    title = "Information",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("card-text"),
+                      "Describe this visualisation."
+                    ),
+                    md_file_to_html("app", "text", "about_heatmaps.md")
+                  )
+                ),
+
                 shiny::selectInput(
                   inputId = "heatmap_type",
                   label = bslib::tooltip(
@@ -526,14 +548,8 @@ app_ui <- function(request) {
                   label = "Bookmark",
                   icon = shiny::icon("bookmark", lib = "glyphicon"),
                   style = "color: #fff; background-color: #337ab7; border-color: #2e6da4"
-                ),
-                bslib::accordion(
-                  open = FALSE,
-                  bslib::accordion_panel(
-                    title = "About",
-                    md_file_to_html("app", "text", "about_heatmaps.md")
-                  )
                 )
+
               ), # end sidebar
               plotly::plotlyOutput("heatmap")
             )
@@ -554,9 +570,13 @@ app_ui <- function(request) {
                 width = 350,
 
                 bslib::accordion(
-                  open = FALSE,
+                  open = TRUE,
                   bslib::accordion_panel(
-                    title = "About",
+                    title = "Information",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("card-text"),
+                      "Describe this table."
+                    ),
                     md_file_to_html("app", "text", "about_mitigator_coverage.md")
                   )
                 )
@@ -580,9 +600,13 @@ app_ui <- function(request) {
                 open = TRUE,
 
                 bslib::accordion(
-                  open = FALSE,
+                  open = TRUE,
                   bslib::accordion_panel(
-                    title = "About",
+                    title = "Information",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("card-text"),
+                      "Describe this table"
+                    ),
                     md_file_to_html("app", "text", "about_scheme_coverage.md")
                   )
                 )
@@ -614,6 +638,18 @@ app_ui <- function(request) {
               sidebar = bslib::sidebar(
                 width = 350,
                 open = TRUE,
+
+                bslib::accordion(
+                  open = FALSE,
+                  bslib::accordion_panel(
+                    title = "Information",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("card-text"),
+                      "Describe this visualisation."
+                    ),
+                    md_file_to_html("app", "text", "about_baseline.md")
+                  )
+                ),
 
                 shiny::checkboxInput(
                   inputId = "toggle_contextual_baseline_range",
@@ -666,14 +702,8 @@ app_ui <- function(request) {
                   label = "Bookmark",
                   icon = shiny::icon("bookmark", lib = "glyphicon"),
                   style = "color: #fff; background-color: #337ab7; border-color: #2e6da4"
-                ),
-                bslib::accordion(
-                  open = FALSE,
-                  bslib::accordion_panel(
-                    title = "About",
-                    md_file_to_html("app", "text", "about_baseline.md")
-                  )
                 )
+
               ), # end sidebar
               plotly::plotlyOutput("contextual_baseline")
             )
@@ -692,6 +722,18 @@ app_ui <- function(request) {
               sidebar = bslib::sidebar(
                 width = 350,
                 open = TRUE,
+
+                bslib::accordion(
+                  open = FALSE,
+                  bslib::accordion_panel(
+                    title = "Information",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("card-text"),
+                      "Describe this visualisation."
+                    ),
+                    md_file_to_html("app", "text", "about_trendline.md")
+                  )
+                ),
 
                 shiny::checkboxInput(
                   inputId = "toggle_contextual_trendline_otherschemes",
@@ -755,14 +797,8 @@ app_ui <- function(request) {
                   label = "Bookmark",
                   icon = shiny::icon("bookmark", lib = "glyphicon"),
                   style = "color: #fff; background-color: #337ab7; border-color: #2e6da4"
-                ),
-                bslib::accordion(
-                  open = FALSE,
-                  bslib::accordion_panel(
-                    title = "About",
-                    md_file_to_html("app", "text", "about_trendline.md")
-                  )
                 )
+
               ), # end sidebar
               plotly::plotlyOutput("contextual_trendline")
             )


### PR DESCRIPTION
closes #121 

# Clarify the 'about' accordions
The PR seeks to increase the visibility of the description sections by:

- Renaming from 'About' to 'Information',
- Adding an icon and tooltip to the accordion header,
- Moving to the top of each sidebar,
- Opening by default where no other input controls are present in the sidebar.

![image](https://github.com/user-attachments/assets/09da230a-6966-4845-b7ee-eaa29107ab0c)

