### PR TITLE
Adorn heatmap scheme names 👕👖👞

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -122,7 +122,8 @@ app_server <- function(input, output, session) {
     dat_return <- update_dat_values(
       dat = dat,
       values_displayed = input$values_displayed,
-      include_point_estimates = input$include_point_estimates
+      include_point_estimates = input$include_point_estimates,
+      focal_scheme_code = input$focus_scheme
     )
 
     return(dat_return)
@@ -321,7 +322,8 @@ app_server <- function(input, output, session) {
         mitigator_order = input$heatmap_mitigator_order,
         values_displayed = input$values_displayed,
         toggle_heatmap_nee = input$toggle_heatmap_nee,
-        toggle_heatmap_aggregate_summaries = input$toggle_heatmap_aggregate_summaries
+        toggle_heatmap_aggregate_summaries = input$toggle_heatmap_aggregate_summaries,
+        toggle_heatmap_scheme_adornments = input$toggle_heatmap_scheme_adornments
       )
 
     return(dat)
@@ -609,7 +611,11 @@ app_server <- function(input, output, session) {
     } else if (temp_scheme_count < 12) {
       base_height <- 200
     } else {
-      base_height <- 300
+      if (input$toggle_heatmap_scheme_adornments) {
+        base_height <- 600
+      } else {
+        base_height <- 300
+      }
     }
 
     # update reactive values

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -586,6 +586,17 @@ app_ui <- function(request) {
                       ),
                       value = FALSE
                     ),
+                    shiny::checkboxInput(
+                      inputId = "toggle_heatmap_scheme_adornments",
+                      label = bslib::tooltip(
+                        trigger = list(
+                          "Adorn scheme names?",
+                          bsicons::bs_icon("info-circle")
+                        ),
+                        "Controls whether scheme names include additional information. Toggle off (default) to show scheme name. Toggle on to see the scheme names along with scheme codes, run stage and years for baseline and horizon."
+                      ),
+                      value = FALSE
+                    ),
                     shiny::selectInput(
                       inputId = "heatmap_scheme_order",
                       label = bslib::tooltip(

--- a/R/fct_tabulate.R
+++ b/R/fct_tabulate.R
@@ -291,9 +291,13 @@ populate_table <- function(
 #' @param dat Tibble of data - as produced from `populate_table` in `fct_tabulate.R`
 #' @param values_displayed Character - the value in `input$values_displayed` indicating the user's preferred view
 #' @param include_point_estimates Boolean - the value in `input$include_point_estimates` indicating whether point-estimates of 0% mitigation (100% prediction) are to be included
+#' @param focal_scheme_code Character - the scheme code of the focal scheme
 #'
 #' @return Tibble of data with the 'value_' and 'nee_' fields updated to match the user's preferred values
-update_dat_values <- function(dat, values_displayed, include_point_estimates = FALSE) {
+update_dat_values <- function(dat,
+                              values_displayed,
+                              include_point_estimates = FALSE,
+                              focal_scheme_code) {
   if (values_displayed == "Percent of activity mitigated") {
     dat <-
       dat |>
@@ -343,6 +347,17 @@ update_dat_values <- function(dat, values_displayed, include_point_estimates = F
       dplyr::filter(!key %in% dat_exclude$key) |>
       dplyr::select(-key)
   }
+
+  # identify the focal scheme
+  dat <-
+    dat |>
+    dplyr::mutate(
+      scheme_name = dplyr::if_else(
+        condition = scheme_code %in% dplyr::coalesce(focal_scheme_code, ""),
+        true = glue::glue("{scheme_name} 📌"),
+        false = scheme_name
+      )
+    )
 
   return(dat)
 }

--- a/inst/app/text/about_heatmaps.md
+++ b/inst/app/text/about_heatmaps.md
@@ -58,6 +58,12 @@ This option controls the visibility of aggregate summaries (minimum, maximum and
 
 Enable this option to include the minimum, maximum and average values on the heatmap plot which is useful when exporting to image - where the tooltip context information is lost.
 
+##### Adorn scheme names?
+
+This option controls whether the scheme name includes additional details, useful when exporting the plot as a static image and the tooltip context information is lost.
+
+Enable this option to extend the scheme names to include scheme code, run stage and years for baseline and horizon.
+
 ##### Order schemes by
 
 Select a value from the drop-down list for how schemes are ordered on the x-axis. The default option is 'Number of mitigators (desc)', with options for:

--- a/man/prepare_heatmap_dat.Rd
+++ b/man/prepare_heatmap_dat.Rd
@@ -14,7 +14,8 @@ prepare_heatmap_dat(
   mitigator_order,
   values_displayed,
   toggle_heatmap_nee = FALSE,
-  toggle_heatmap_aggregate_summaries = FALSE
+  toggle_heatmap_aggregate_summaries = FALSE,
+  toggle_heatmap_scheme_adornments = FALSE
 )
 }
 \arguments{
@@ -35,6 +36,8 @@ prepare_heatmap_dat(
 \item{toggle_heatmap_nee}{Boolean (default = FALSE) should the display include a column for NEE values for mitigators?}
 
 \item{toggle_heatmap_aggregate_summaries}{Boolean (default = FALSE) should the display include columns showing minimum, maximum and mean values for each mitigator?}
+
+\item{toggle_heatmap_scheme_adornments}{Boolean (default = FALSE) should the scheme details include additional information such as scheme code, run stage and horizon year?}
 }
 \value{
 Tibble of data ready for use with heatmap plots

--- a/man/update_dat_values.Rd
+++ b/man/update_dat_values.Rd
@@ -4,7 +4,12 @@
 \alias{update_dat_values}
 \title{Update dat to reflect the user's preferred values}
 \usage{
-update_dat_values(dat, values_displayed, include_point_estimates = FALSE)
+update_dat_values(
+  dat,
+  values_displayed,
+  include_point_estimates = FALSE,
+  focal_scheme_code
+)
 }
 \arguments{
 \item{dat}{Tibble of data - as produced from `populate_table` in `fct_tabulate.R`}
@@ -12,6 +17,8 @@ update_dat_values(dat, values_displayed, include_point_estimates = FALSE)
 \item{values_displayed}{Character - the value in `input$values_displayed` indicating the user's preferred view}
 
 \item{include_point_estimates}{Boolean - the value in `input$include_point_estimates` indicating whether point-estimates of 0% mitigation (100% prediction) are to be included}
+
+\item{focal_scheme_code}{Character - the scheme code of the focal scheme}
 }
 \value{
 Tibble of data with the 'value_' and 'nee_' fields updated to match the user's preferred values


### PR DESCRIPTION
closes #104 

# Adorn heatmap scheme names with additional contextual details
This PR introduces a checkbox to control whether heatmap scheme names include details such as the scheme code, run stage and years for the baseline and horizon.

## Screenshots
👕 A new checkbox controls whether scheme names are 'adorned' with additional details:
![image](https://github.com/user-attachments/assets/95fd8991-38e4-4b29-a532-b72f1965ac29)

👖 The additional details are visible when the heatmap is exported as an image and so provide valuable context in situations where the hovertext is not available:
![image](https://github.com/user-attachments/assets/608ea847-6f5e-4d95-89bc-3a13250a0cbf)

👞 Brucie-bonus - '📌' is now used more visualisations to denote the focal scheme:
![image](https://github.com/user-attachments/assets/2d4fe614-39cc-46e9-9080-4675023f0386)
