### PR TITLE
Add double-deploy script

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -19,7 +19,7 @@ app_server <- function(input, output, session) {
   container_inputs <-
     get_container(container_name = Sys.getenv("AZ_STORAGE_CONTAINER_INPUTS"))
 
-  board <- pins::board_connect()
+  board <- pins::board_connect(server = "connect.strategyunitwm.nhs.uk")
 
   ## Read data ----
 

--- a/dev/03_deploy.R
+++ b/dev/03_deploy.R
@@ -1,59 +1,24 @@
-# Building a Prod-Ready, Robust Shiny Application.
-#
-# README: each step of the dev files is optional, and you don't have to
-# fill every dev scripts before getting started.
-# 01_start.R should be filled at start.
-# 02_dev.R should be used to keep track of your development during the project.
-# 03_deploy.R should be used once you need to deploy your app.
-#
-#
-######################################
-#### CURRENT FILE: DEPLOY SCRIPT #####
-######################################
+# Deploy to the current and new Posit Connect servers. The current server
+# (strategyunitwm.nhs.uk) will be switched off in May/June 2025 and the new
+# server (currently named su.mlcsu.org) will take its name.
 
-# Test your app
+deploy <- function(server_name, app_id) {
+  rsconnect::deployApp(
+    appName = "nhp_inputs_report_app",
+    appTitle = "NHP Mitigator Comparison App",
+    appFiles = c(
+      "R/",
+      "inst/",
+      "NAMESPACE",
+      "DESCRIPTION",
+      "app.R"
+    ),
+    server = server_name,
+    appId = app_id,
+    lint = FALSE,
+    forceUpdate = TRUE
+  )
+}
 
-## Run checks ----
-## Check the package before sending to prod
-# devtools::check()
-# rhub::check_for_cran()
-
-# Deploy
-
-## Local, CRAN or Package Manager ----
-## This will build a tar.gz that can be installed locally,
-## sent to CRAN, or to a package manager
-# devtools::build()
-
-## RStudio ----
-## If you want to deploy on RStudio related platforms
-# golem::add_rstudioconnect_file()
-# golem::add_shinyappsio_file()
-# golem::add_shinyserver_file()
-
-## Docker ----
-## If you want to deploy via a generic Dockerfile
-# golem::add_dockerfile_with_renv()
-
-## If you want to deploy to ShinyProxy
-# golem::add_dockerfile_with_renv_shinyproxy()
-
-
-# Deploy to Posit Connect or ShinyApps.io
-# In command line.
-rsconnect::deployApp(
-  appName = "nhp_inputs_report_app",
-  appTitle = "NHP Mitigator Comparison App",
-  appFiles = c(
-    # Add any additional files unique to your app here.
-    "R/",
-    "inst/",
-    # "data/",
-    "NAMESPACE",
-    "DESCRIPTION",
-    "app.R"
-  ),
-  appId = rsconnect::deployments(".")$appID,
-  lint = FALSE,
-  forceUpdate = TRUE
-)
+deploy("connect.strategyunitwm.nhs.uk", 298)
+deploy("connect.su.mlcsu.org", 108)


### PR DESCRIPTION
Close #144.

* Makes a `deploy()` function to allow the app to deployed to both the old and new servers.
* Made the {pin} board server name explicit.
* I've checked it works by deploying to both servers (the one on the new server won't work until the pins are transferred and the old server gets renamed).
