### PR TITLE
Fix connect-publish action

### DIFF
--- a/.github/workflows/connect-publish.yaml
+++ b/.github/workflows/connect-publish.yaml
@@ -14,7 +14,8 @@ jobs:
           r-version: latest
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-renv@v2
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
 
       - name: Create manifest.json
         shell: Rscript {0}

--- a/.github/workflows/connect-publish.yaml
+++ b/.github/workflows/connect-publish.yaml
@@ -14,6 +14,8 @@ jobs:
           r-version: latest
           use-public-rspm: true
 
+      - uses: r-lib/actions/setup-renv@v2
+
       - name: Create manifest.json
         shell: Rscript {0}
         run: |

--- a/.github/workflows/connect-publish.yaml
+++ b/.github/workflows/connect-publish.yaml
@@ -16,6 +16,9 @@ jobs:
 
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+            extra-packages: |
+                any::rsconnect
 
       - name: Create manifest.json
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,10 @@
 Package: nhp.inputs.report.app
 Title: NHP Mitigator Comparison App
-Version: 0.7.2
+Version: 0.8.1
 Authors@R: c(
     person("Matt", "Dray", , "matt.dray@nhs.net", role = c("cre", "aut")),
     person("Craig", "Parylo", role = "aut"),
+    person("Claire", "Welsh", role = "ctb"),
     person("Ozayr", "Mohammed", role = "ctb"),
     person("Anya", "Ferguson", role = "ctb")
   )
@@ -52,6 +53,7 @@ Imports:
     withr,
     yaml
 Suggests: 
+    rsconnect,
     testthat (>= 3.0.0)
 Remotes: 
     dreamRs/datamods


### PR DESCRIPTION
Close #186.

* Added {renv} step to Action.
* Added {rsconnect} to suggests in `DESCRIPTION`.
* Add @DCEW to authors in `DESCRIPTION`.
* Bump `DESCRIPTION` to v0.8.1.

[The Action failed](https://github.com/The-Strategy-Unit/nhp_inputs_report_app/actions/runs/17124679395) because {rsconnect} was unavailable. Are the first two bullets above overkill? Could I just add a step in [the Action](https://github.com/The-Strategy-Unit/nhp_inputs_report_app/blob/main/.github/workflows/connect-publish.yaml) (before creating the manifest) like:

```
- name: Install rsconnect
  shell: Rscript {0}
  run: |
    install.packages("rsconnect")
```