### PR TITLE
Read new rates column

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -27,7 +27,7 @@ app_server <- function(input, output, session) {
       procode = .data$provider,
       .data$strategy,
       .data$fyear,
-      .data$rate,
+      rate = .data$std_rate,
       n = .data$denominator
     )
 
@@ -57,11 +57,11 @@ app_server <- function(input, output, session) {
   # Parameters
   params <- pins::pin_read(
     board,
-    name = "matt.dray/nhp_tagged_runs_params_test"
+    name = "matt.dray/nhp_tagged_runs_params"
   )
   runs_meta <- pins::pin_read(
     board,
-    name = "matt.dray/nhp_tagged_runs_meta_test"
+    name = "matt.dray/nhp_tagged_runs_meta"
   )
   extracted_params <- extract_params(
     params,


### PR DESCRIPTION
Close #232.

* Read `std_rate` column from new-style `rates.parquet`, name as 'rate'.
* Read from 'live' pins instead of test ones.

I've [deployed this branch to the dev app](https://connect.strategyunitwm.nhs.uk/nhp/compare-mitigation-predictions-dev/) to prove it works (compare to [the prod version](https://connect.strategyunitwm.nhs.uk/nhp/compare-mitigation-predictions/), which errors because it's looking for a column that doesn't exist).