### PR TITLE
Update inputs data path

### DIFF
--- a/R/fct_azure.R
+++ b/R/fct_azure.R
@@ -102,7 +102,7 @@ read_provider_data <- function(
 ) {
   parquet_in <- AzureStor::storage_download(
     container_inputs,
-    src = glue::glue("{inputs_data_version}/{file}.parquet"),
+    src = glue::glue("{inputs_data_version}/provider/{file}.parquet"),
     dest = NULL
   )
 


### PR DESCRIPTION
Close #234.

* Added `provider/` to the path when reading from inputs data (because of the new directory structure implemented from model v4.4.0).
* [Redeployed to dev](https://connect.strategyunitwm.nhs.uk/nhp/compare-mitigation-predictions-dev/) to prove it works.