### PR TITLE
Add buttons to add/remove all schemes

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -140,9 +140,6 @@ app_server <- function(input, output, session) {
     )
   })
 
-  #
-  shiny::setBookmarkExclude("toggle_all_schemes")
-
   # Reactives ----
 
   # ensure dat reflects the user's preferred view
@@ -397,17 +394,13 @@ app_server <- function(input, output, session) {
     )
   })
 
+  # Choose focal scheme, update with focus scheme + peer set
   shiny::observe({
     scheme_and_peers <- c(input$focus_scheme, peer_set())
     selected_schemes <- all_schemes[which(all_schemes %in% scheme_and_peers)] |>
       tibble::enframe() |>
       dplyr::arrange(.data$name) |> # sort on name, not code
       tibble::deframe()
-
-    if (input$toggle_all_schemes) {
-      selected_schemes <- all_schemes
-    }
-
     shiny::updateSelectInput(
       session,
       "schemes",
@@ -415,6 +408,28 @@ app_server <- function(input, output, session) {
       selected = selected_schemes
     )
   })
+
+  # Add-all schemes button
+  shiny::observe(
+    shiny::updateSelectInput(
+      session,
+      "schemes",
+      choices = all_schemes,
+      selected = all_schemes
+    )
+  ) |>
+    shiny::bindEvent(input$add_all_schemes)
+
+  # Remove-all button (keep only focus scheme)
+  shiny::observe(
+    shiny::updateSelectInput(
+      session,
+      "schemes",
+      choices = all_schemes,
+      selected = input$focus_scheme
+    )
+  ) |>
+    shiny::bindEvent(input$remove_all_schemes)
 
   # indicate how many mitigators are available for selection
   shiny::observe({

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -140,6 +140,9 @@ app_server <- function(input, output, session) {
     )
   })
 
+  #
+  shiny::setBookmarkExclude("toggle_all_schemes")
+
   # Reactives ----
 
   # ensure dat reflects the user's preferred view

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -57,7 +57,7 @@ app_ui <- function(request) {
               multiple = TRUE
             ),
             shiny::checkboxInput(
-              inputId = "toggle_all_schemes",
+              inputId = "toggle_all_schemes", # excluded from bookmarking
               label = bslib::tooltip(
                 trigger = list(
                   "Select all schemes?",

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -56,16 +56,20 @@ app_ui <- function(request) {
               selected = NULL,
               multiple = TRUE
             ),
-            shiny::checkboxInput(
-              inputId = "toggle_all_schemes", # excluded from bookmarking
-              label = bslib::tooltip(
-                trigger = list(
-                  "Select all schemes?",
-                  bsicons::bs_icon("info-circle")
-                ),
-                "Automatically select all schemes at once."
+            shiny::div(
+              style = "display: flex; gap: 8px;",
+              shiny::actionButton(
+                inputId = "add_all_schemes",
+                label = "Add all",
+                icon = shiny::icon("plus"),
+                style = "flex: 1;"
               ),
-              value = FALSE
+              shiny::actionButton(
+                inputId = "remove_all_schemes",
+                label = "Remove all",
+                icon = shiny::icon("minus"),
+                style = "flex: 1;"
+              )
             )
           ),
           ### mitigator select ----


### PR DESCRIPTION
Close #99.

* Remove 'select all schemes' checkbox.
* Replace with buttons to 'add all' and 'remove all' (the checkbox was causing interference in bookmarking; I also think it was the the wrong interface for this job anyway).
* [Deployed to dev](https://connect.strategyunitwm.nhs.uk/nhp/compare-mitigation-predictions-dev/).

Preview:

<img width="369" height="337" alt="image" src="https://github.com/user-attachments/assets/ff0148ab-6066-4125-bd83-627393e10d5e" />
