### PR TITLE
Prefer validation to final scenarios

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -67,7 +67,7 @@ app_server <- function(input, output, session) {
     params,
     runs_meta,
     mitigator_lookup,
-    "final_report_ndg2"
+    c("validation_report_ndg2", "final_report_ndg2") # order by preference
   )
   skeleton_table <- prepare_skeleton_table(extracted_params)
 

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -37,7 +37,7 @@ app_ui <- function(request) {
                   "Focal scheme",
                   bsicons::bs_icon("info-circle")
                 ),
-                "The scheme of interest to highlight in visualisations. Autoselects that scheme's peers to also be visualised."
+                "The scheme of interest to highlight in visualisations. Autoselects peers to be visualised."
               ),
               choices = NULL,
               selected = NULL,
@@ -50,7 +50,7 @@ app_ui <- function(request) {
                   "Schemes to visualise",
                   bsicons::bs_icon("info-circle")
                 ),
-                "Schemes to show in plots and tables. Peers autoselected when a focal scheme is selected. Use buttons to add/remove all."
+                "Peers autoselected when a focal scheme is selected. Use buttons to add/remove all."
               ),
               choices = NULL,
               selected = NULL,

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -37,7 +37,7 @@ app_ui <- function(request) {
                   "Focal scheme",
                   bsicons::bs_icon("info-circle")
                 ),
-                "The scheme to highlight in plots. Causes autoselection of peers."
+                "The scheme of interest to highlight in visualisations. Autoselects that scheme's peers to also be visualised."
               ),
               choices = NULL,
               selected = NULL,
@@ -50,7 +50,7 @@ app_ui <- function(request) {
                   "Schemes to visualise",
                   bsicons::bs_icon("info-circle")
                 ),
-                "Defaults to peers of the selected scheme if 'Select all schemes?' is unchecked."
+                "Schemes to show in plots and tables. Peers autoselected when a focal scheme is selected. Use buttons to add/remove all."
               ),
               choices = NULL,
               selected = NULL,

--- a/R/fct_lookups.R
+++ b/R/fct_lookups.R
@@ -2,11 +2,6 @@ make_raw_dt <- function(dat) {
   dat_prepared <- dat |>
     dplyr::filter(!is.na(.data$value_lo)) |> # only want mitigators selected by schemes
     dplyr::mutate(
-      # remove any pencil emojis from scheme names
-      scheme_name = stringr::str_remove(
-        string = .data$scheme_name,
-        pattern = " \\[preliminary\\]"
-      ),
       dplyr::across(
         c(
           tidyselect::starts_with("scheme"),

--- a/R/fct_plots.R
+++ b/R/fct_plots.R
@@ -658,8 +658,7 @@ plot_baseline_comparison <- function(
     200 + (n_mitigators * facet_height_px)
 
   # convert to plotly and tweak settings
-  plot <-
-    plot |>
+  plot |>
     plotly::ggplotly(tooltip = c("text"), height = plot_height) |>
     plotly::config(
       displaylogo = FALSE,
@@ -677,8 +676,6 @@ plot_baseline_comparison <- function(
       font = list(family = "Arial, Helvetica, Droid Sans, sans"),
       hoverlabel = list(font = list(size = 16))
     )
-
-  return(plot)
 }
 
 #' Wrap a vector of strings to fit a specified width
@@ -738,7 +735,7 @@ wrap_strings_to_fit_pixel_limit <- function(
     dplyr::ungroup() # end the rowwise operation
 
   # return the output strings
-  return(df$output)
+  df$output
 }
 
 
@@ -1088,16 +1085,14 @@ plot_trendline_comparison <- function(
 
   # return plot or data
   if (return_data) {
-    return(
-      list(
-        dat_lu = dat_lu,
-        plot_data = plot_data,
-        plot_data_horizon = plot_data_horizon_focal,
-        df_horizon_overlay = df_horizon_overlay
-      )
+    list(
+      dat_lu = dat_lu,
+      plot_data = plot_data,
+      plot_data_horizon = plot_data_horizon_focal,
+      df_horizon_overlay = df_horizon_overlay
     )
   } else {
-    return(plot)
+    plot
   }
 }
 
@@ -1326,20 +1321,18 @@ plot_faceted_trendlines <- function(
   })
 
   # return the plot
-  if (return_data == FALSE) {
-    return(plot)
+  if (!return_data) {
+    plot
   } else {
-    return(
-      list(
-        dat = dat,
-        rates_data = rates_data,
-        mitigator_codes = mitigator_codes,
-        focal_scheme_code = focal_scheme_code,
-        scheme_codes = scheme_codes,
-        dat_lu = dat_lu,
-        plot_data = plot_data,
-        plots = plots
-      )
+    list(
+      dat = dat,
+      rates_data = rates_data,
+      mitigator_codes = mitigator_codes,
+      focal_scheme_code = focal_scheme_code,
+      scheme_codes = scheme_codes,
+      dat_lu = dat_lu,
+      plot_data = plot_data,
+      plots = plots
     )
   }
 }

--- a/R/fct_plots_heatmap.R
+++ b/R/fct_plots_heatmap.R
@@ -612,8 +612,7 @@ prepare_heatmap_dat <- function(
   )
 
   # order scheme and mitigator names to match codes
-  dat <-
-    dat |>
+  dat |>
     dplyr::mutate(
       # need to reverse ordering for y-axis to ensure correct display in ggplot2
       mitigator_code = .data$mitigator_code |>
@@ -648,9 +647,6 @@ prepare_heatmap_dat <- function(
         forcats::fct() |>
         stats::reorder(as.numeric(.data$mitigator_code)),
     )
-
-  # return the result
-  return(dat)
 }
 
 #' Plot heatmap
@@ -927,8 +923,7 @@ plot_heatmap <- function(
   )
 
   # do final config to heatmap
-  heatmap <-
-    heatmap |>
+  heatmap |>
     plotly::config(
       displaylogo = FALSE,
       modeBarButtons = list(list("toImage")),
@@ -941,8 +936,6 @@ plot_heatmap <- function(
         ) # datetime
       )
     )
-
-  return(heatmap)
 }
 
 
@@ -1119,7 +1112,7 @@ heatmap_base <- function(
       margin = list(t = 50, b = 0, l = 0, r = 0)
     )
 
-  if (include_x_axis == FALSE) {
+  if (!include_x_axis) {
     heatmap <-
       heatmap |>
       plotly::layout(

--- a/R/fct_plots_heatmap.R
+++ b/R/fct_plots_heatmap.R
@@ -57,9 +57,8 @@ prepare_heatmap_dat <- function(
     dat <-
       dat |>
       dplyr::mutate(
-        # strip out the pencil and pushpin emojis
         scheme_name = .data$scheme_name |>
-          stringr::str_remove_all(pattern = " \\[(preliminary|focal)\\]"),
+          stringr::str_remove_all(pattern = " \\[focal\\]"),
         # add in the requested adornments
         scheme_name = glue::glue(
           "{scheme_name} ",

--- a/R/fct_tabulate.R
+++ b/R/fct_tabulate.R
@@ -205,11 +205,7 @@ populate_table <- function(
       # schemes
       scheme_name = .data$scheme_name,
       scheme_code = .data$peer,
-      scheme_year = dplyr::if_else(
-        stringr::str_detect(.data$run_stage, "Final"),
-        paste0(.data$peer_year, "*"),
-        .data$peer_year
-      ),
+      scheme_year = .data$peer_year,
       # model run
       run_scenario = .data$scenario,
       .data$run_stage,

--- a/R/fct_tabulate.R
+++ b/R/fct_tabulate.R
@@ -66,12 +66,12 @@ extract_params <- function(
 filter_run_stage_preferentially <- function(params_extracted, run_stage_prefs) {
   preferred_run_stage_by_peer <- params_extracted |>
     dplyr::filter(.data$run_stage %in% .env$run_stage_prefs) |>
-    dplyr::distinct(peer, run_stage) |>
+    dplyr::distinct(.data$peer, .data$run_stage) |>
     dplyr::mutate(
-      run_stage = factor(run_stage, levels = .env$run_stage_prefs)
+      run_stage = factor(.data$run_stage, levels = .env$run_stage_prefs)
     ) |>
-    dplyr::group_by(peer) |>
-    dplyr::arrange(run_stage) |> # preference order given by factor levels
+    dplyr::group_by(.data$peer) |>
+    dplyr::arrange(.data$run_stage) |> # preference order given by factor levels
     dplyr::slice(1) |> # first row will be the most-preferred factor level
     dplyr::ungroup()
 
@@ -352,8 +352,7 @@ update_dat_values <- function(
   }
 
   # identify the focal scheme
-  dat <-
-    dat |>
+  dat |>
     dplyr::mutate(
       scheme_name = dplyr::if_else(
         condition = .data$scheme_code %in%
@@ -362,8 +361,6 @@ update_dat_values <- function(
         false = .data$scheme_name
       )
     )
-
-  return(dat)
 }
 
 #' Forecast a scheme's value for a given forecast year

--- a/R/fct_tabulate.R
+++ b/R/fct_tabulate.R
@@ -1,4 +1,21 @@
-extract_params <- function(params, runs_meta, mitigator_lookup, run_stages_rx) {
+#' Isolate the Params for Preferred Scenarios
+#' Get one params-set per scheme to be shown in the app, selected in order of
+#' preferred run-stage values.
+#' @param params A list of lists. Each element is a given scenario's params.
+#' @param runs_meta A data.frame. Scenario names and create datetimes for all
+#'     schemes' model runs that are tagged with a `run_stage` value.
+#' @param mitigator_lookup A data.frame. A lookup of TPMAs, labels and groups.
+#' @param run_stage_prefs Character vector of `run_stage` values, ordered by
+#'     preference. So `c("validation_report_ndg2", "final_report_ndg2")` will
+#'     preferentially filter for 'validation', otherwise 'final'.
+#' @return A list of lists.
+#' @noRd
+extract_params <- function(
+  params,
+  runs_meta,
+  mitigator_lookup,
+  run_stage_prefs
+) {
   possibly_report_params_table <- purrr::possibly(report_params_table)
 
   activity_avoidance <- params |>
@@ -33,8 +50,35 @@ extract_params <- function(params, runs_meta, mitigator_lookup, run_stages_rx) {
 
   params_extracted |>
     dplyr::filter(
-      .data$strategy %in% mitigator_lookup[["Strategy variable"]],
-      stringr::str_detect(.data$run_stage, .env$run_stages_rx)
+      .data$strategy %in% mitigator_lookup[["Strategy variable"]]
+    ) |>
+    filter_run_stage_preferentially(run_stage_prefs)
+}
+
+#' Filter for Scenarios with Preferred Run Stage Values
+#' @param params_extracted A data.frame. Prediction intervals for each TPMA for
+#'     each scheme's scenarios.
+#' @param run_stage_prefs Character vector of `run_stage` values, ordered by
+#'     preference. So `c("validation_report_ndg2", "final_report_ndg2")` will
+#'     preferentially filter for 'validation', otherwise 'final'.
+#' @return A data.frame.
+#' @noRd
+filter_run_stage_preferentially <- function(params_extracted, run_stage_prefs) {
+  preferred_run_stage_by_peer <- params_extracted |>
+    dplyr::filter(.data$run_stage %in% .env$run_stage_prefs) |>
+    dplyr::distinct(peer, run_stage) |>
+    dplyr::mutate(
+      run_stage = factor(run_stage, levels = .env$run_stage_prefs)
+    ) |>
+    dplyr::group_by(peer) |>
+    dplyr::arrange(run_stage) |> # preference order given by factor levels
+    dplyr::slice(1) |> # first row will be the most-preferred factor level
+    dplyr::ungroup()
+
+  params_extracted |>
+    dplyr::semi_join(
+      preferred_run_stage_by_peer,
+      by = c("peer", "run_stage")
     )
 }
 

--- a/R/fct_tabulate.R
+++ b/R/fct_tabulate.R
@@ -203,17 +203,7 @@ populate_table <- function(
     dplyr::mutate(
       .keep = "none",
       # schemes
-      scheme_name = dplyr::case_when(
-        # identify schemes whose mitigators are not yet finalised
-        !is.na(.data$scheme_name) &
-          stringr::str_starts(
-            string = .data$run_stage |> stringr::str_to_lower(),
-            pattern = "final",
-            negate = TRUE
-          ) ~
-          glue::glue("{scheme_name} [preliminary]"),
-        .default = .data$scheme_name
-      ),
+      scheme_name = .data$scheme_name,
       scheme_code = .data$peer,
       scheme_year = dplyr::if_else(
         stringr::str_detect(.data$run_stage, "Final"),

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ It also saves [a CSV file to another pin](https://connect.strategyunitwm.nhs.uk/
 The app then reads data from these pins using [the {pins} package](https://pins.rstudio.com/).
 A [blogpost by the Data Science team](https://the-strategy-unit.github.io/data_science/blogs/posts/2024-05-22-storing-data-safely/#posit-connect-pins) contains a note on authenticating RStudio with Posit Connect, should you need to.
 
-Schemes run many scenarios, but the app only displays data from a single scenario, preferably the one used to compile their outputs ('final') report.
-MRMs tell the Data Science team which particular results file should be labelled manually on Azure with the 'run stage' metadata of 'final' (and possibly 'intermediate' or 'initial').
+Schemes run many scenarios, but the app only displays data from a single scenario; by preference the one used in their validation report, otherwise their 'final' report.
+MRMs tell the Data Science team which particular results file should be labelled manually on Azure with the 'run stage' metadata
 There's [a handy lookup table](https://connect.strategyunitwm.nhs.uk/nhp/tagged_runs/nhp-tagged-runs.html) (login/permissions required) where you can see the scenario files that have been given run-stage metadata.
 
 #### Supporting

--- a/inst/app/text/info_data.md
+++ b/inst/app/text/info_data.md
@@ -1,6 +1,6 @@
 Scenario selection
 
-* The data presented in this app originates from model scenarios identified by each scheme as the 'final' one used in their outputs report.
+* The data presented in this app originates from model scenarios identified by each scheme as the one used for their 'validation' reports, otherwise the 'final' one used in their outputs report.
 * The results of [the National Elicitation Exercise (NEE)](https://doi.org/10.1136/bmjopen-2024-084632) (expert predictions for 2039/40) are presented in the app for reference, but note that some TPMAs were not part of that exercise.
 * Data were recorded in [the NHP Inputs app](https://connect.strategyunitwm.nhs.uk/nhp/inputs/) as 80% prediction intervals (a lower and upper value) for a chosen horizon (final) year, but you can choose to view the data here as the percent of activity mitigated instead.
 

--- a/inst/app/text/info_data.md
+++ b/inst/app/text/info_data.md
@@ -1,6 +1,6 @@
 Scenario selection
 
-* The data presented in this app originates from model scenarios identified by each scheme as the one used for their 'validation' reports, otherwise the 'final' one used in their outputs report.
+* The data presented in this app originates from model scenarios that each scheme has used in the 'validation' stage of reporting, otherwise the original outputs ('final') stage.
 * The results of [the National Elicitation Exercise (NEE)](https://doi.org/10.1136/bmjopen-2024-084632) (expert predictions for 2039/40) are presented in the app for reference, but note that some TPMAs were not part of that exercise.
 * Data were recorded in [the NHP Inputs app](https://connect.strategyunitwm.nhs.uk/nhp/inputs/) as 80% prediction intervals (a lower and upper value) for a chosen horizon (final) year, but you can choose to view the data here as the percent of activity mitigated instead.
 


### PR DESCRIPTION
Close #237, close #126.

* Prefer to show results for a validation scenario, otherwise final.
* Tweak wording given this change.
* Remove redundant labelling of 'preliminary' (non-final, non-validation) runs.

[Deployed to dev](connect.strategyunitwm.nhs.uk/nhp/compare-mitigation-predictions-dev/).