### PR TITLE
Open the sidebar conditionally

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -471,6 +471,16 @@ app_server <- function(input, output, session) {
   ## Enablers ----
 
   shiny::observe({
+    # Sidebar options only relevant to certain pages
+    if (input$page_navbar %in% c("Information", "Data")) {
+      bslib::toggle_sidebar("sidebar", open = FALSE)
+    } else {
+      bslib::toggle_sidebar("sidebar", open = TRUE)
+    }
+  }) |>
+    shiny::bindEvent(input$page_navbar)
+
+  shiny::observe({
     if (input$heatmap_type == "value_binary") {
       # enable
 

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -21,6 +21,7 @@ app_ui <- function(request) {
       ## sidebar ----
       sidebar = bslib::sidebar(
         id = "sidebar",
+        open = "closed",
         width = 400,
         bslib::accordion(
           id = "global_accordion",


### PR DESCRIPTION
Close #241.

* Close the sidebar on panels that don't need it (information and data).
* Open the sidebar on panels that need it (prediction intervals, heatmaps, contextual).