### PR TITLE
Add warning accordion panel to each viz

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -306,6 +306,15 @@ app_ui <- function(request) {
                   ),
 
                   bslib::accordion_panel(
+                    title = "Comparisons",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("exclamation-triangle"),
+                      "A note on comparing schemes' predictions"
+                    ),
+                    md_file_to_html("app", "text", "info_warning.md")
+                  ),
+
+                  bslib::accordion_panel(
                     title = "Controls",
                     icon = bslib::tooltip(
                       trigger = bsicons::bs_icon("toggles"),
@@ -463,6 +472,15 @@ app_ui <- function(request) {
                   ),
 
                   bslib::accordion_panel(
+                    title = "Comparisons",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("exclamation-triangle"),
+                      "A note on comparing schemes' predictions"
+                    ),
+                    md_file_to_html("app", "text", "info_warning.md")
+                  ),
+
+                  bslib::accordion_panel(
                     title = "Controls",
                     icon = bslib::tooltip(
                       trigger = bsicons::bs_icon("toggles"),
@@ -573,6 +591,15 @@ app_ui <- function(request) {
                       "Describe this visualisation"
                     ),
                     md_file_to_html("app", "text", "about_heatmaps.md")
+                  ),
+
+                  bslib::accordion_panel(
+                    title = "Comparisons",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("exclamation-triangle"),
+                      "A note on comparing schemes' predictions"
+                    ),
+                    md_file_to_html("app", "text", "info_warning.md")
                   ),
 
                   bslib::accordion_panel(
@@ -821,6 +848,15 @@ app_ui <- function(request) {
                   ),
 
                   bslib::accordion_panel(
+                    title = "Comparisons",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("exclamation-triangle"),
+                      "A note on comparing schemes' predictions"
+                    ),
+                    md_file_to_html("app", "text", "info_warning.md")
+                  ),
+
+                  bslib::accordion_panel(
                     title = "Downloads",
                     icon = bslib::tooltip(
                       trigger = bsicons::bs_icon("box-arrow-down"),
@@ -866,6 +902,15 @@ app_ui <- function(request) {
                       "Describe this visualisation"
                     ),
                     md_file_to_html("app", "text", "about_scheme_coverage.md")
+                  ),
+
+                  bslib::accordion_panel(
+                    title = "Comparisons",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("exclamation-triangle"),
+                      "A note on comparing schemes' predictions"
+                    ),
+                    md_file_to_html("app", "text", "info_warning.md")
                   ),
 
                   bslib::accordion_panel(
@@ -923,6 +968,15 @@ app_ui <- function(request) {
                       "Describe this visualisation"
                     ),
                     md_file_to_html("app", "text", "about_baseline.md")
+                  ),
+
+                  bslib::accordion_panel(
+                    title = "Comparisons",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("exclamation-triangle"),
+                      "A note on comparing schemes' predictions"
+                    ),
+                    md_file_to_html("app", "text", "info_warning.md")
                   ),
 
                   bslib::accordion_panel(
@@ -1045,6 +1099,15 @@ app_ui <- function(request) {
                       "Describe this visualisation"
                     ),
                     md_file_to_html("app", "text", "about_trendline.md")
+                  ),
+
+                  bslib::accordion_panel(
+                    title = "Comparisons",
+                    icon = bslib::tooltip(
+                      trigger = bsicons::bs_icon("exclamation-triangle"),
+                      "A note on comparing schemes' predictions"
+                    ),
+                    md_file_to_html("app", "text", "info_warning.md")
                   ),
 
                   bslib::accordion_panel(


### PR DESCRIPTION
Close #216.

* Added a '⚠️ Comparisons' accordion panel to each visualisation panel that usese the text we already show in a card in the 'information' panel.

<img width="910" height="533" alt="Screenshot of the app showing that there's a new accordion panel named 'comparisons' with a warning triangle icon, which is excpanded to show text that explains users should be wary when comparing predictions between schemes." src="https://github.com/user-attachments/assets/c15d39b9-9475-4a24-adb9-571b4ba6cc23" />