### PR TITLE
Recommend {pak} instead of deprecated function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The app is built primarily with the R packages [{shiny}](https://shiny.posit.co/
 
 #### Install packages
 
-You must ensure you have installed the packages listed in the `DESCRIPTION`.
-These can be installed with `devtools::install_deps(dependencies = TRUE)`.
+You must ensure you have installed all the packages listed in the `DESCRIPTION`.
+These can be installed with `pak::local_install_deps(dependencies = TRUE)`.
 This repo doesn't use {renv}.
 
 #### Add environmental variables


### PR DESCRIPTION
Close #245.

* Replaced `devtools::install_dependencies()` (deprecated) with `pak::local_install_deps()` in the `README`.